### PR TITLE
fix: missing app

### DIFF
--- a/betterlyze/betterlyze/template-settings.py
+++ b/betterlyze/betterlyze/template-settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "django_tables2",
     'bootstrap3',
     'django_filters',
+    'betterlyze',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
missed to add 'betterlyze' to the settings template with the latest push